### PR TITLE
Save depth images as pickle object to preserve information.

### DIFF
--- a/vision/camera/README.md
+++ b/vision/camera/README.md
@@ -6,6 +6,41 @@ All camera modules have a generic interface so they can be swapped out easily.
 The following are examples of how to use the camera child classes. As always, make sure to either change file import paths,
 or to download everything into the same file.
 
+### Reading Images
+
+#### .jpg/.png
+
+These are standard image formats, used for color images.
+
+```python
+import cv2
+
+## Saving
+cv2.imwrite("filename", ndarray) -> bool
+
+## Reading
+cv2.imread("filename") -> ndarray
+```
+
+#### .obj
+
+This is a pickle object file, used for depth images.
+
+```python
+## Saving .obj
+with open('filename.obj', 'wb') as file:
+    pickle.dump(ndarray, file)
+
+## Reading .obj
+with open('filename.obj', 'rb') as file:
+    ndarray = pickle.load(file)
+```
+
+#### .bag
+
+This is a rosbag file, used for color+depth videos.
+Use the bag_file reader, follow instructions for that class below.
+
 ### Realsense Example
 
 If only one realsense is plugged in, the code will run normally. If you are using more than one camera, make sure to specify the serial number.

--- a/vision/camera/README.md
+++ b/vision/camera/README.md
@@ -22,18 +22,18 @@ cv2.imwrite("filename", ndarray) -> bool
 cv2.imread("filename") -> ndarray
 ```
 
-#### .obj
+#### .npy
 
-This is a pickle object file, used for depth images.
+This is a numpy array file, used for depth images.
 
 ```python
-## Saving .obj
-with open('filename.obj', 'wb') as file:
-    pickle.dump(ndarray, file)
+## Saving .npy
+with open('filename.npy', 'wb') as file:
+    pickle.dump(file, ndarray)
 
-## Reading .obj
-with open('filename.obj', 'rb') as file:
-    ndarray = pickle.load(file)
+## Reading .npy
+with open('filename.npy', 'rb') as file:
+    ndarray = numpy.load(file)
 ```
 
 #### .bag

--- a/vision/util/capture_airsim_image.py
+++ b/vision/util/capture_airsim_image.py
@@ -9,6 +9,9 @@ To capture/save images, start and run the airsim. Then, navigate to
 the location of this program in terminal, and run using
 "python capture_airsim_image.py". Enter q to capture an image, or e to exit.
 """
+import datetime
+import pickle
+import cv2
 import airsim
 
 client = airsim.MultirotorClient()
@@ -16,18 +19,17 @@ client = airsim.MultirotorClient()
 while True:  # runs as long as the simulator is running, ideally
     key = input("Enter q to capture scene and depth images, or e to exit. ")
     if key == "q":
-        sceneCameraImage = client.simGetImage("0", airsim.ImageType.Scene)  # reportedly this is an png returned, not sure how that works
+        ## TODO get as numpy array
+        # reportedly this is an png returned, not sure how that works
+        sceneCameraImage = client.simGetImage("0", airsim.ImageType.Scene)
         depthCameraImage = client.simGetImage("3", airsim.ImageType.Scene)
-        f = open('sceneFrame.png', 'wb')
-        f.write(sceneCameraImage)
-        f.close()
-        g = open('depthFrame.png', 'wb')
-        g.write(depthCameraImage)
-        g.close()
 
-    # get numpy array
-    # img1d = np.fromstring(cameraImage.image_data_uint8, dtype=np.uint8)
+        time = str(datetime.datetime.now()).replace(' ', '_').replace(':', '.')
+
+        cv2.imwrite(f"{time}-colorImage.jpg", sceneCameraImage)
+
+        with open(f"{time}-depthImage.obj", 'wb') as file:
+            pickle.dump(depthCameraImage, file)
 
     if key == "e":
         break
-

--- a/vision/util/capture_airsim_image.py
+++ b/vision/util/capture_airsim_image.py
@@ -12,6 +12,7 @@ the location of this program in terminal, and run using
 import datetime
 import pickle
 import cv2
+import numpy as np
 import airsim
 
 client = airsim.MultirotorClient()
@@ -28,8 +29,8 @@ while True:  # runs as long as the simulator is running, ideally
 
         cv2.imwrite(f"{time}-colorImage.jpg", sceneCameraImage)
 
-        with open(f"{time}-depthImage.obj", 'wb') as file:
-            pickle.dump(depthCameraImage, file)
+        with open(f"{time}-depthImage.npy", 'wb') as file:
+            np.save(file, depthCameraImage)
 
     if key == "e":
         break

--- a/vision/util/take_picture.py
+++ b/vision/util/take_picture.py
@@ -2,6 +2,7 @@
 Called to save a depth and color frame with timed labels
 """
 import datetime
+import pickle
 import cv2
 
 
@@ -19,5 +20,6 @@ def save_camera_frame(depth_frame, color_frame):
     time = str(datetime.datetime.now()).replace(' ', '_').replace(':', '.')
 
     cv2.imwrite(f"{time}-colorImage.jpg", color_frame)
-    cv2.imwrite(f"{time}-depthImage.jpg", depth_frame)
 
+    with open(f"{time}-depthImage.obj", 'wb') as file:
+        pickle.dump(depth_frame, file)

--- a/vision/util/take_picture.py
+++ b/vision/util/take_picture.py
@@ -3,7 +3,7 @@ Called to save a depth and color frame with timed labels
 """
 import datetime
 import pickle
-import cv2
+import cv2, numpy as np
 
 
 def save_camera_frame(depth_frame, color_frame):
@@ -21,5 +21,5 @@ def save_camera_frame(depth_frame, color_frame):
 
     cv2.imwrite(f"{time}-colorImage.jpg", color_frame)
 
-    with open(f"{time}-depthImage.obj", 'wb') as file:
-        pickle.dump(depth_frame, file)
+    with open(f"{time}-depthImage.npy", 'wb') as file:
+        np.save(file, depth_frame)


### PR DESCRIPTION
A pickle object or numpy binary seem to be the only file types to save depth image as, potentially a csv file could work since depth is 2d but I think we should use something that will generalize to higher number channels. I have tried all of the file types that opencv supports but they are all capped at integers of 255 and floats of 1, where the depth images are ~6k+.
I have validated this with a realsense camera. The airsim capture is untested.