### PR TITLE
Add pre-commit auto-formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black
+      language_version: python3.8
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.5.0  # Use the ref you want to point at
+    hooks:
+    -   id: trailing-whitespace
+    -   id: check-added-large-files
+    -   id: check-merge-conflict
+    -   id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ To run our competition code, you will need:
       and testing in AirSim, so start with jMAVSim
     - Run the make command in the PX4 Firmware repository
 
+5. Clone this repository to any location with
+  ```bash
+  git clone --recursive https://github.com/MissouriMRR/IARC-2020
+  ```
+
+6. Install pre-commit for auto-formatting and sanity checking from [here](https://pre-commit.com/#install)
+
+7. Run the pre-commit linker
+  ```bash
+  pre-commit install
+  ```
+
 5. In the root of this repository, run the following to create a virtual
    environment and install our packages:
 
@@ -111,4 +123,3 @@ To run our competition code, you will need:
 
 We adopt the MIT License for our projects. Please read the [LICENSE](https://github.com/MissouriMRR/IARC-2020/blob/master/LICENSE)
 file for more info
-


### PR DESCRIPTION
Due to my use of a code auto-formatter to make clean code named `black`, I frequently end up stealing changes to files in this repository by simply opening up files as `black` will run and change several lines. `black` is an excellent auto-formatter and I have decided to setup git to automagically auto-format on commit. Included are README changes to denote how to get it working