### PR TITLE
Manual landing function

### DIFF
--- a/flight/config.py
+++ b/flight/config.py
@@ -38,6 +38,7 @@ FAST_THINK_S: float = 1.0
 
 
 async def config_params(drone: System):
+    return
     await drone.param.set_param_float("MIS_TAKEOFF_ALT", TAKEOFF_ALT)
     await drone.param.set_param_float("MPC_XY_VEL_MAX", MAX_SPEED)
     await drone.param.set_param_float("MPC_XY_CRUISE", MAX_SPEED)

--- a/flight/states/land.py
+++ b/flight/states/land.py
@@ -17,6 +17,22 @@ class Land(State):
     offboard
     """
 
+    async def manual_land(self, drone: System):
+        # Lands the drone using manual velocity values
+        logging.info("Landing the drone...")
+        async for position in drone.telemetry.position():
+            current_altitude: float = round(position.relative_altitude_m, 3)
+            if current_altitude > 0.5:
+                # 0.7 m/s is default velocity used in drone.action.land() command, can be changed if necessary
+                await drone.offboard.set_velocity_body(sdk.offboard.VelocityBodyYawspeed(0.0, 0.0, 0.7, 0.0))
+            elif 0.5 > current_altitude > 0:
+                await drone.offboard.set_velocity_body(sdk.offboard.VelocityBodyYawspeed(0.0, 0.0, 0.35, 0.0))
+            else:
+                await drone.offboard.set_velocity_body(sdk.offboard.VelocityBodyYawspeed(0.0, 0.0, 0.0, 0.0))
+                break
+        return
+
+
     async def run(self, drone: System) -> State:
         """
         Stops the drone by setting all movements to 0, then move to land
@@ -29,6 +45,7 @@ class Land(State):
         )
 
         await asyncio.sleep(config.THINK_FOR_S)
+        await self.manual_land(drone)
 
         try:
             await drone.offboard.stop()
@@ -36,10 +53,4 @@ class Land(State):
             logging.exception(
                 "Stopping offboard mode failed with error code: %s", str(error)
             )
-            # TODO Worried about what happens here
-
-        await asyncio.sleep(config.THINK_FOR_S)
-
-        logging.info("Landing the drone")
-        await drone.action.land()
         return Final()


### PR DESCRIPTION
Manual Landing function uses offboard to give the drone velocity for its descent; from its current height to 0.5 meters it descends at 0.7m/s, and from 0.5 meters to 0 meters it descends at 0.35m/s.