### PR TITLE
Added module roll function to module_orientation.py

### DIFF
--- a/vision/module/module_bounding.py
+++ b/vision/module/module_bounding.py
@@ -3,6 +3,8 @@ Find the region of the image that the module lies within.
 """
 
 import numpy as np
+import cv2
+import argparse
 
 MODULE_HEIGHT = 76.2  # mm
 MODULE_WIDTH = 50.8  # mm
@@ -10,6 +12,7 @@ VERTICAL_FOV = 57  # degrees
 HORIZONTAL_FOV = 86  # degrees
 
 PADDING_CONSTANT = 1.15
+
 
 def getModuleBounds(dimensions, center, depth):
     """
@@ -29,7 +32,7 @@ def getModuleBounds(dimensions, center, depth):
     list - list of the four tuple vertices.
     """
     x, y = center
-    vert_res, horiz_res, _ = dimensions
+    vert_res, horiz_res = dimensions
 
     vert_angle = np.degrees(np.arctan((MODULE_HEIGHT / 2) / depth))
     horiz_angle = np.degrees(np.arctan((MODULE_HEIGHT / 2) / depth))
@@ -46,3 +49,31 @@ def getModuleBounds(dimensions, center, depth):
     bottom_left = (x - horiz_val, y + vert_val)
 
     return [top_left, top_right, bottom_right, bottom_left]
+
+
+if __name__ == "__main__":
+    """
+    Driver for testing module_bounding
+    """
+    # # Create object for parsing command-line options
+    parser = argparse.ArgumentParser(description="Read .npy file and test for get_module_depth.\
+                                            To read a .npy file, type \"python module_bounding.py --i (image number))\"")
+    # # Add argument which takes path to a bag file as an input
+    parser.add_argument("-i", "--input", type=str, help="Path to the .npy file")
+    # # Parse the command line arguments to an object
+    args = parser.parse_args()
+
+    if args.input:
+        colorImage = cv2.imread(args.input + "-colorImage.jpg")
+        depthImage = np.load(args.input + "-depthImage.npy")
+    else:
+        raise FileNotFoundError("No input parameter has been given. For help type --help")
+
+    # gets rid of outliers, should be done before the arguments are calculated at all
+    depthImage = np.clip(depthImage, np.percentile(depthImage, 10), np.percentile(depthImage, 90))
+
+    tl, tr, br, bl = getModuleBounds((1080, 1920), (995, 600), depthImage[600][995])
+    colorImage = colorImage[tl[1]:bl[1], bl[0]:br[0]]
+
+    cv2.imshow("Module Bounding", colorImage)
+    cv2.waitKey(0)

--- a/vision/module/module_orientation.py
+++ b/vision/module/module_orientation.py
@@ -3,6 +3,7 @@ module_orientation will calculate the orientation of the module in degrees
 and return them as a tuple (x tilt, y tilt) using a derivative through the x- and y- axes
 """
 import numpy as np
+import cv2
 
 
 def get_module_orientation(roi):
@@ -22,11 +23,59 @@ def get_module_orientation(roi):
     x_avg_diff = np.mean(roi[:, -1] / 1000 - roi[:, 0] / 1000)
     x_tilt = np.degrees(np.arctan(x_avg_diff))
 
-
     y_avg_diff = np.mean(roi.T[:, -1] / 1000 - roi.T[:, 0] / 1000)
     y_tilt = np.degrees(np.arctan(y_avg_diff))
 
     return x_tilt, y_tilt
+
+
+def get_module_roll(enclosing_region):
+    # contours only work on grey images
+    enclosing_region = cv2.cvtColor(enclosing_region, cv2.COLOR_BGR2GRAY)
+
+    edges = cv2.Canny(enclosing_region, 150, 450)
+
+    contours = cv2.findContours(edges, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)[0]
+    # use the following line to visualize contours, pair with imshow
+    # colorImage = cv2.drawContours(enclosing_region, contours, -1, (0, 255, 0), 3)
+
+    # simple contours will contain the list of contours with fewer than 8 vertices
+    simple_contours = []
+    for c in contours:
+        approx = cv2.approxPolyDP(c, 0.01 * cv2.arcLength(c, True), True)
+        if len(approx) < 8:
+            simple_contours.append(c)
+            enclosing_region = cv2.drawContours(enclosing_region, c, -1, (0, 255, 0), 3)
+
+    # draws minimum area rectangles to enclose the contours
+    # presumably, since thee module contours (or module edge contours) will rectangles at some angle,
+    #   the min area rectangles will be at or around that same angle
+    rectangles = [cv2.minAreaRect(c) for c in simple_contours]
+
+    # for visualization, if desired
+    # enclosing_region = cv2.cvtColor(enclosing_region, cv2.COLOR_GRAY2BGR)
+
+    # sums the angles of the min area rectangles
+    sum_angle = 0
+    divisor = 0
+    for rect in rectangles:
+        box = cv2.boxPoints(rect)
+        box = np.int0(box)
+
+        # visualization
+        # cv2.drawContours(colorImage, [box], 0, (0, 0, 255), 2)
+
+        # if the angle is absurd, it won't be taken
+        #   if the module is truly rolled at over 45 degrees, minAreaRect
+        #   should simply choose a different rectangle or axis
+        if abs(rect[2]) < 45:
+            sum_angle += rect[2]
+            divisor += 1
+
+    # averages the angles of the enclosing min area rectangles around the contours
+    roll = sum_angle / divisor
+
+    return roll
 
 
 if __name__ == "__main__":
@@ -55,6 +104,8 @@ if __name__ == "__main__":
         raise FileNotFoundError("No input parameter has been given. For help type --help")
 
     depthImage = np.load(depthNpy)
+
+    # to test roll, import getModuleBounds from module_bounding and use that to find the enclosing region
 
     # values for the test depth image
     center = (650, 560)

--- a/vision/module/module_orientation.py
+++ b/vision/module/module_orientation.py
@@ -85,8 +85,8 @@ def get_module_roll(enclosing_region: np.ndarray) -> float:
     # if the angle is absurd, it won't be taken
     #   if the module is truly rolled at over 45 degrees, minAreaRect
     #   should simply choose a different rectangle or axis
-    np.where(abs(angles) < 45, angles, angles)
-    roll = np.mean(angles)
+    mask = np.where(abs(angles) < 45)
+    roll = np.mean(angles[mask])
 
     return roll
 


### PR DESCRIPTION
get_module_roll has been added to module_orientation.py

To test, either copy the function into module_bounding.py and run from there, or import module_bounding's getModuleBounds into module_orientation.py. Since there is no yet a working center function, to my knowledge, manually input the center/depth indices for the image you want to test. Commented visualization lines have also been added for convenience.