### PR TITLE
Resolve mean of empty slice and ragged array numpy warnings

### DIFF
--- a/vision/module/get_module_depth.py
+++ b/vision/module/get_module_depth.py
@@ -57,9 +57,11 @@ def get_module_depth(depth_image: np.ndarray, coordinates: tuple) -> float:
     # Gets rid of 0 depth values
     depth_values_in_radius = depth_values_in_radius[depth_values_in_radius != 0]
 
-    avg = np.mean(depth_values_in_radius)
-    if np.isnan(avg):
+    if depth_values_in_radius.size == 0:  # no depth values in radius = no avg
         return 0
+
+    avg = np.mean(depth_values_in_radius)
+
     return avg
 
 

--- a/vision/module/location.py
+++ b/vision/module/location.py
@@ -75,7 +75,7 @@ class ModuleLocation:
 
         best_slope_heights = self.best_grouped_slopes[0]
 
-        return np.any(best_slope_heights > MIN_SLOPES_IN_BUCKET)
+        return np.any(best_slope_heights >= MIN_SLOPES_IN_BUCKET)
 
     ## Finding the Center
 

--- a/vision/module/module_orientation.py
+++ b/vision/module/module_orientation.py
@@ -8,7 +8,7 @@ import numpy as np
 import cv2
 
 
-def get_module_orientation(roi):
+def get_module_orientation(roi: np.ndarray) -> tuple:
     """
     Finds the orientation of the module in degrees
 
@@ -19,9 +19,11 @@ def get_module_orientation(roi):
 
     Returns
     -----------
-    tuple of floating point values, degrees in coordinates of
-        the tilt on the x and y axes, respectively
+    tuple(float) - degrees in coordinates of the tilt on the x and y axes, respectively
     """
+    if roi.size == 0:
+        return 0.0, 0.0
+
     x_avg_diff = np.mean(roi[:, -1] / 1000 - roi[:, 0] / 1000)
     x_tilt = np.degrees(np.arctan(x_avg_diff))
 
@@ -43,9 +45,11 @@ def get_module_roll(enclosing_region: np.ndarray) -> float:
 
     Returns
     -----------
-    roll
-        module roll with respect to the positive y axis in degrees
+    float - module roll with respect to the positive y axis in degrees
     """
+    if enclosing_region.size == 0:
+        return 0.0
+
     # contours only work on grey images
     enclosing_region = cv2.cvtColor(enclosing_region, cv2.COLOR_BGR2GRAY)
 
@@ -79,14 +83,14 @@ def get_module_roll(enclosing_region: np.ndarray) -> float:
     #     box = np.int0(box)
     #     cv2.drawContours(colorImage, [box], 0, (0, 0, 255), 2)
 
-    np_rectangles = np.asarray(rectangles)
+    np_rectangles = np.asarray(rectangles, dtype=object)
 
     # NOTE: this try block exists such that the [:, 2] slice of
     #         np_rectangles can be attempted without risking
     #         crashing the algorithm and logging the failure flag
     try:
         angles = np_rectangles[:, 2]
-        
+
         roll = np.mean(angles)
     except:
         roll = 0


### PR DESCRIPTION
- Resolved mean of empty slice numpy warnings caused by module depth and module roll functions
Mean of empty slice warning occurs when numpy attempts numpy.mean on an empty numpy array
- Resolved numpy ragged array warning caused by module roll's casting of the rectangles, being a ragged 2D python list, to numpy array without labeling the data type as "object"